### PR TITLE
Mathieu huot

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -90,5 +90,6 @@ module.exports = function (eleventyConfig) {
 			input: 'src',
 		},
 		htmlTemplateEngine: 'njk',
+		markdownTemplateEngine: 'njk'
 	};
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "cross-env NODE_ENV=production eleventy && cross-env NODE_ENV=production postcss src/static/css/tailwind.css --o _site/static/css/style.css"
   },
   "devDependencies": {
-    "@11ty/eleventy": "^0.11.1",
+    "@11ty/eleventy": "^0.12.1",
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.1.0",
     "@tailwindcss/typography": "^0.4.0",
     "alpinejs": "^2.8.1",

--- a/src/tagmenu.html
+++ b/src/tagmenu.html
@@ -18,7 +18,7 @@ pagination:
 		<ul class="list-none">
 			{% for tag in collections.pageTags %}
 			<li class="text-xl">
-				<a href="/tagmenu-tags/{{ tag }}"> {{tag}} </a>
+				<a href="/tags/{{ tag }}"> {{tag}} </a>
 			</li>
 
 			{% endfor %}

--- a/src/tagmenuTags.njk
+++ b/src/tagmenuTags.njk
@@ -4,7 +4,7 @@ pagination:
     data: collections.myPages
     size: 1
 	alias: tagmenuTags
-permalink: tagmenu-tags/{{ tag }}
+permalink: tagmenu-tags/{{ pagination.pageNumber }}/
 ---
 
 <div class="flex flex-col w-full">

--- a/src/tagmenuTags2.njk
+++ b/src/tagmenuTags2.njk
@@ -36,3 +36,4 @@ permalink: pages2/{{ pageTags2 | lower | slug }}/
       
 		</tbody>
 </section>
+{% endfor %}

--- a/src/tagmenuTags2.njk
+++ b/src/tagmenuTags2.njk
@@ -5,7 +5,7 @@ pagination:
   size: 1
   alias: tag
 addAllPagesToCollections: true
-permalink: pages2/{{ pageTags2 | lower | slug }}/
+permalink: pages2/{{ pagination.pageNumber }}/
 ---
 {% set pages = collections[tag] | reverse %}
 


### PR DESCRIPTION
Here's the adjustment that I made:

1. Processing `md` files through Nunjucks seemed to fix the "tag set not found" error. Added markdownTemplateEngine: "njk" in .eleventy.js.
2. Once got that sorted, the `use distinct permalink` came back. Looking closer, it appears that the last part of your permalink in tagmenuTags.njk (the {{ tag }} part) was being ignored. So I replace that with `permalink: tagmenu-tags/{{ pagination.pageNumber }}/`. I did the same in tagmenuTags2.njk which was yield the same error.
3. Also, I noticed that your tag links in tagmenu.html appeared to be broken so I replace the `href` with `href="/tags/{{ tag }}"`.
4. Finally, I bumped Eleventy to v 0.12.1 to fixed vulnerability issue.
5. If you got question, don't hesitate.