### PR TITLE
Replaced tagmenu-tags with tags in tag listing.

### DIFF
--- a/src/tagmenu.html
+++ b/src/tagmenu.html
@@ -18,7 +18,7 @@ pagination:
 		<ul class="list-none">
 			{% for tag in collections.pageTags %}
 			<li class="text-xl">
-				<a href="/tagmenu-tags/{{ tag }}"> {{tag}} </a>
+				<a href="/tags/{{ tag }}/"> {{tag}} </a>
 			</li>
 
 			{% endfor %}


### PR DESCRIPTION
Your tag pages are living in the *tags* directory. However, you had your listing link in *tagmenu.html* pointing to `/tagmenu-tags/{{ tag }}/`which don't exist hence the broken links. So I replace the `href` there with `/tags/{{ tag }}/`. I tested the site and it's working as expected! Now you have a little cleaning to do. ;-)